### PR TITLE
Skip creating SQL when house number is not numeric

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Replace '2019' with the current year throughout.
 
         # Ubuntu:
         sudo apt-get install python3-gdal unzip
+        pip3 install ogr
 
   2. Get the TIGER 2019 data. You will need the EDGES files
      (3,233 zip files, 11GB total).

--- a/tiger_address_convert.py
+++ b/tiger_address_convert.py
@@ -451,8 +451,8 @@ def addressways(waylist, nodelist, first_id):
                             elif ltofromint and (lfromint % 2) == 0 and (ltoint % 2) == 0:
                                 interpolationtype = "odd";
 
-                    ret.append( "SELECT tiger_line_import(ST_GeomFromText('LINESTRING(%s)',4326), %s, %s, %s, %s, %s, %s);" %
-                                ( ",".join(rlinestring), sql_quote(rfromadd), sql_quote(rtoadd), sql_quote(interpolationtype), sql_quote(name), sql_quote(county), sql_quote(zipr) ) )
+                        ret.append( "SELECT tiger_line_import(ST_GeomFromText('LINESTRING(%s)',4326), %s, %s, %s, %s, %s, %s);" %
+                                    ( ",".join(rlinestring), sql_quote(rfromadd), sql_quote(rtoadd), sql_quote(interpolationtype), sql_quote(name), sql_quote(county), sql_quote(zipr) ) )
 
                 if left:
                     id += 1
@@ -470,8 +470,8 @@ def addressways(waylist, nodelist, first_id):
                             elif rtofromint and (rfromint %2 ) == 0 and (rtoint % 2) == 0:
                                 interpolationtype = "odd";
 
-                    ret.append( "SELECT tiger_line_import(ST_GeomFromText('LINESTRING(%s)',4326), %s, %s, %s, %s, %s, %s);" %
-                                ( ",".join(llinestring), sql_quote(lfromadd), sql_quote(ltoadd), sql_quote(interpolationtype), sql_quote(name), sql_quote(county), sql_quote(zipl) ) )
+                        ret.append( "SELECT tiger_line_import(ST_GeomFromText('LINESTRING(%s)',4326), %s, %s, %s, %s, %s, %s);" %
+                                    ( ",".join(llinestring), sql_quote(lfromadd), sql_quote(ltoadd), sql_quote(interpolationtype), sql_quote(name), sql_quote(county), sql_quote(zipl) ) )
 
     return ret
 


### PR DESCRIPTION
Part of https://github.com/osm-search/TIGER-data/issues/2

The script has variables
```
                rtofromint = right        #Do the addresses convert to integers?
                ltofromint = left        #Do the addresses convert to integers?
```
but later when the values are `False` it still printed the SQL.
