### PR TITLE
generate CSV, not SQL files

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ US TIGER address data for Nominatim
 ===================================
 
 Convert [TIGER](https://www.census.gov/geographies/mapping-files/time-series/geo/tiger-line-file.html)/Line
-dataset of the US Census Bureau to SQL files which can be imported by Nominatim. In Nominatim the created
+dataset of the US Census Bureau to CSV files which can be imported by Nominatim. In Nominatim the created
 tables are separate from OpenStreetMap tables and get queried at search time separately.
 
 The dataset gets updated once per year. Downloading is prone to be slow (can take a full day) and converting
@@ -13,7 +13,7 @@ Replace '2020' with the current year throughout.
   1. Install the GDAL library and python bindings and the unzip tool
 
         # Ubuntu:
-        sudo apt-get install python3-gdal unzip
+        sudo apt-get install python3-gdal python3-pip unzip
         pip3 install ogr
 
   2. Get the TIGER 2020 data. You will need the EDGES files
@@ -21,7 +21,7 @@ Replace '2020' with the current year throughout.
 
          wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2020/EDGES/
 
-  3. Convert the data into SQL statements. Adjust the file paths in the scripts as needed
+  3. Convert the data into CSV files. Adjust the file paths in the scripts as needed
 
         ./convert.sh <input-path> <output-path>
 

--- a/convert.sh
+++ b/convert.sh
@@ -28,7 +28,7 @@ for F in ${INFILES[*]}; do
     if [[ "$F" =~ $INREGEX ]]; then
         COUNTYID=${BASH_REMATCH[1]}
         SHAPEFILE="$WORKPATH/$(basename $F '.zip').shp"
-        SQLFILE="$OUTPATH/$COUNTYID.sql"
+        CSVFILE="$OUTPATH/$COUNTYID.csv"
 
         unzip -o -q -d "$WORKPATH" "$F"
         if [[ ! -e "$SHAPEFILE" ]]; then
@@ -36,13 +36,13 @@ for F in ${INFILES[*]}; do
             exit 1
         fi
 
-        ./tiger_address_convert.py "$SHAPEFILE" "$SQLFILE"
+        ./tiger_address_convert.py "$SHAPEFILE" "$CSVFILE"
 
         rm $WORKPATH/*
     fi
 done
 
-OUTFILES=($OUTPATH/*.sql)
+OUTFILES=($OUTPATH/*.csv)
 echo "Wrote ${#OUTFILES[*]} files."
 
 rmdir $WORKPATH


### PR DESCRIPTION
Fixes https://github.com/osm-search/TIGER-data/issues/6

In https://github.com/osm-search/TIGER-data/pull/7 @lonvia created a script which exported CSV files from a Nominatim database. With this PR we generate the CSV files directly.

The CSV header has a column `city` while the values are really counties. In https://github.com/osm-search/Nominatim/blob/master/nominatim/tools/tiger_data.py I only see street and postcode used.

```python3
            address = dict(street=row['street'], postcode=row['postcode'])
```

There's two differences:

   1. The database export rounds numbers in the WKN geometry, e.g.` -76.572064 36.26145` vs `-76.572064 36.261450`

   2. The database doesn't contain roads with empty county and state (`in_isin` in Nominatim 3.5). That affects 285 rows, e.g. `61;57;all;BIA Hwy 32;;;57770;LINESTRING(-102.576881 43.026187,-102.576644 43.026188)`

If we account for those, the output is the same

```bash
wget https://nominatim.org/data/tiger2020-nominatim-preprocessed.csv.tar.gz
tar -xzf tiger2020-nominatim-preprocessed.csv.tar.gz
cat tiger/*.csv > /tmp/fromdb.csv
./convert.sh tiger2020_census_gov_mirror/ newscript
cat newscript/*.csv | perl -nE '($f,$l)=$_=~m/^(.+);(.+)/;$l=~s/(-?\d+\.\d+?)0+\b/$1*1/ge; say"$f;$l"' > /tmp/newscript.csv

wc -l /tmp/*.csv
   34271716 /tmp/fromdb.csv
   34272001 /tmp/newscript.csv

grep -c ';;;' /tmp/newscript.csv
285

diff /tmp/fromdb.csv /tmp/newscript.csv | grep -v ';;;'
(outputs no lines)
```