### PR TITLE
tiger_address_convert.py - first pylint fixes

### DIFF
--- a/tiger_address_convert.py
+++ b/tiger_address_convert.py
@@ -1,12 +1,28 @@
 #!/usr/bin/python3
-# Tiger road data to OSM conversion script
-# Creates Karlsruhe-style address ways beside the main way
-# based on the Massachusetts GIS script by christopher schmidt
 
-#BUGS:
-# On very tight curves, a loop may be generated in the address way.
-# It would be nice if the ends of the address ways were not pulled back from dead ends
+"""
+Tiger road data to OSM conversion script
+Creates Karlsruhe-style address ways beside the main way
+based on the Massachusetts GIS script by christopher schmidt
 
+BUGS:
+- On very tight curves, a loop may be generated in the address way.
+- It would be nice if the ends of the address ways were not pulled back from dead ends
+"""
+
+import sys
+import os.path
+import json
+import re
+import csv
+import math
+
+try:
+    from osgeo import ogr
+    from osgeo import osr
+except:
+    import ogr
+    import osr
 
 # Ways that include these mtfccs should not be uploaded
 # H1100 Connector
@@ -19,23 +35,28 @@
 # P0002 Perennial Shoreline
 # P0003 Intermittent Shoreline
 # P0004 Other non-visible bounding Edge (e.g., Census water boundary, boundary of an areal feature)
-ignoremtfcc = [ "H1100", "H3010", "H3013", "H3020", "L4130", "L4140", "P0001", "P0002", "P0003", "P0004" ]
+ignoremtfcc = [
+    "H1100",
+    "H3010",
+    "H3013",
+    "H3020",
+    "L4130",
+    "L4140",
+    "P0001",
+    "P0002",
+    "P0003",
+    "P0004"
+]
 
 # Sets the distance that the address ways should be from the main way, in feet.
-address_distance = 30
+ADDRESS_DISTANCE = 30
 
-# Sets the distance that the ends of the address ways should be pulled back from the ends of the main way, in feet
-address_pullback = 45
+# Sets the distance that the ends of the address ways should be pulled back
+# from the ends of the main way, in feet
+ADDRESS_PULLBACK = 45
 
-import sys, os.path, json, re, csv
-try:
-    from osgeo import ogr
-    from osgeo import osr
-except:
-    import ogr
-    import osr
 
-# https://www.census.gov/geo/reference/codes/cou.html 
+# https://www.census.gov/geo/reference/codes/cou.html
 # tiger_county_fips.json was generated from the following:
 # wget https://www2.census.gov/geo/docs/reference/codes/files/national_county.txt
 # cat national_county.txt | perl -F, -naE'($F[0] ne 'AS') && $F[3] =~ s/ ((city|City|County|District|Borough|City and Borough|Municipio|Municipality|Parish|Island|Census Area)(?:, |\Z))+//; say qq(  "$F[1]$F[2]": "$F[3], $F[0]",)'
@@ -46,33 +67,33 @@ def parse_shp_for_geom_and_tags( filename ):
     #ogr.RegisterAll()
 
     dr = ogr.GetDriverByName("ESRI Shapefile")
-    poDS = dr.Open( filename )
+    po_ds = dr.Open( filename )
 
-    if poDS == None:
+    if po_ds is None:
         raise "Open failed."
 
-    poLayer = poDS.GetLayer( 0 )
+    po_layer = po_ds.GetLayer( 0 )
 
     fieldNameList = []
-    layerDefinition = poLayer.GetLayerDefn()
-    for i in range(layerDefinition.GetFieldCount()):
-        fieldNameList.append(layerDefinition.GetFieldDefn(i).GetName())
+    layer_definition = po_layer.GetLayerDefn()
+    for i in range(layer_definition.GetFieldCount()):
+        fieldNameList.append(layer_definition.GetFieldDefn(i).GetName())
     # sys.stderr.write(",".join(fieldNameList))
 
-    poLayer.ResetReading()
+    po_layer.ResetReading()
 
     ret = []
 
-    poFeature = poLayer.GetNextFeature()
-    while poFeature:
+    po_feature = po_layer.GetNextFeature()
+    while po_feature:
         tags = {}
-        
+
         # WAY ID
-        tags["tiger:way_id"] = int( poFeature.GetField("TLID") )
-        
+        tags["tiger:way_id"] = int( po_feature.GetField("TLID") )
+
         # FEATURE IDENTIFICATION
-        mtfcc = poFeature.GetField("MTFCC");
-        if mtfcc != None:
+        mtfcc = po_feature.GetField("MTFCC")
+        if mtfcc is not None:
 
             if mtfcc == "L4010":        #Pipeline
                 tags["man_made"] = "pipeline"
@@ -88,14 +109,14 @@ def parse_shp_for_geom_and_tags( filename ):
                 tags["route"] = "ferry"
             if mtfcc == "R1011":        #Railroad Feature (Main, Spur, or Yard)
                 tags["railway"] = "rail"
-                ttyp = poFeature.GetField("TTYP")
-                if ttyp != None:
+                ttyp = po_feature.GetField("TTYP")
+                if ttyp is not None:
                     if ttyp == "S":
                         tags["service"] = "spur"
                     if ttyp == "Y":
                         tags["service"] = "yard"
                     tags["tiger:ttyp"] = ttyp
-            if mtfcc == "R1051":        #Carline, Streetcar Track, Monorail, Other Mass Transit Rail)
+            if mtfcc == "R1051":        # Carline, Streetcar Track, Monorail, Other Mass Transit Rail
                 tags["railway"] = "light_rail"
             if mtfcc == "R1052":        #Cog Rail Line, Incline Rail Line, Tram
                 tags["railway"] = "incline"
@@ -135,9 +156,9 @@ def parse_shp_for_geom_and_tags( filename ):
             tags["tiger:mtfcc"] = mtfcc
 
         # FEATURE NAME
-        if poFeature.GetField("FULLNAME"):
+        if po_feature.GetField("FULLNAME"):
             #capitalizes the first letter of each word
-            name = poFeature.GetField( "FULLNAME" )
+            name = po_feature.GetField( "FULLNAME" )
             tags["name"] = name
 
             #Attempt to guess highway grade
@@ -151,60 +172,60 @@ def parse_shp_for_geom_and_tags( filename ):
                 if tags["highway"] != "primary":
                     tags["highway"] = "secondary"
 
-        statefp = poFeature.GetField("STATEFP")
-        countyfp = poFeature.GetField("COUNTYFP")
-        if (statefp != None) and (countyfp != None):
+        statefp = po_feature.GetField("STATEFP")
+        countyfp = po_feature.GetField("COUNTYFP")
+        if (statefp is not None) and (countyfp is not None):
             county_name = county_fips_data.get(statefp + '' + countyfp)
             if county_name:
                 tags["tiger:county"] = county_name
 
-        # tlid = poFeature.GetField("TLID")
-        # if tlid != None:
+        # tlid = po_feature.GetField("TLID")
+        # if tlid is not None:
         #     tags["tiger:tlid"] = tlid
 
-        lfromadd = poFeature.GetField("LFROMADD")
-        if lfromadd != None:
+        lfromadd = po_feature.GetField("LFROMADD")
+        if lfromadd is not None:
             tags["tiger:lfromadd"] = lfromadd
 
-        rfromadd = poFeature.GetField("RFROMADD")
-        if rfromadd != None:
+        rfromadd = po_feature.GetField("RFROMADD")
+        if rfromadd is not None:
             tags["tiger:rfromadd"] = rfromadd
 
-        ltoadd = poFeature.GetField("LTOADD")
-        if ltoadd != None:
+        ltoadd = po_feature.GetField("LTOADD")
+        if ltoadd is not None:
             tags["tiger:ltoadd"] = ltoadd
 
-        rtoadd = poFeature.GetField("RTOADD")
-        if rtoadd != None:
+        rtoadd = po_feature.GetField("RTOADD")
+        if rtoadd is not None:
             tags["tiger:rtoadd"] = rtoadd
 
-        zipl = poFeature.GetField("ZIPL")
-        if zipl != None:
+        zipl = po_feature.GetField("ZIPL")
+        if zipl is not None:
             tags["tiger:zip_left"] = zipl
 
-        zipr = poFeature.GetField("ZIPR")
-        if zipr != None:
+        zipr = po_feature.GetField("ZIPR")
+        if zipr is not None:
             tags["tiger:zip_right"] = zipr
 
         if mtfcc not in ignoremtfcc:
             # COPY DOWN THE GEOMETRY
             geom = []
-            
-            rawgeom = poFeature.GetGeometryRef()
+
+            rawgeom = po_feature.GetGeometryRef()
             for i in range( rawgeom.GetPointCount() ):
                 geom.append( (rawgeom.GetX(i), rawgeom.GetY(i)) )
-    
+
             ret.append( (geom, tags) )
-        poFeature = poLayer.GetNextFeature()
-        
+        po_feature = po_layer.GetNextFeature()
+
     return ret
 
 
 # ====================================
 # to do read .prj file for this data
-# Change the Projcs_wkt to match your datas prj file.
+# Change the PROJCS_WKT to match your datas prj file.
 # ====================================
-projcs_wkt = \
+PROJCS_WKT = \
 """GEOGCS["GCS_North_American_1983",
         DATUM["D_North_American_1983",
         SPHEROID["GRS_1980",6378137,298.257222101]],
@@ -212,7 +233,7 @@ projcs_wkt = \
         UNIT["Degree",0.017453292519943295]]"""
 
 from_proj = osr.SpatialReference()
-from_proj.ImportFromWkt( projcs_wkt )
+from_proj.ImportFromWkt( PROJCS_WKT )
 
 # output to WGS84
 to_proj = osr.SpatialReference()
@@ -220,14 +241,13 @@ to_proj.SetWellKnownGeogCS( "EPSG:4326" )
 
 tr = osr.CoordinateTransformation( from_proj, to_proj )
 
-import math
 def length(segment, nodelist):
     '''Returns the length (in feet) of a segment'''
     first = True
     distance = 0
     lat_feet = 364613  #The approximate number of feet in one degree of latitude
     for point in segment:
-        pointid, (lat, lon) = nodelist[ round_point( point ) ]
+        _pointid, (lat, lon) = nodelist[ round_point( point ) ]
         if first:
             first = False
         else:
@@ -241,7 +261,7 @@ def length(segment, nodelist):
 def addressways(waylist, nodelist, first_id):
     id = first_id
     lat_feet = 364613  #The approximate number of feet in one degree of latitude
-    distance = float(address_distance)
+    distance = float(ADDRESS_DISTANCE)
     csv_lines = []
 
     for waykey, segments in waylist.items():
@@ -255,10 +275,10 @@ def addressways(waylist, nodelist, first_id):
 
             # Don't pull back the ends of very short ways too much
             seglength = length(segment, nodelist)
-            if seglength < float(address_pullback) * 3.0:
+            if seglength < float(ADDRESS_PULLBACK) * 3.0:
                 pullback = seglength / 3.0
             else:
-                pullback = float(address_pullback)
+                pullback = float(ADDRESS_PULLBACK)
             if "tiger:lfromadd" in waykey:
                 lfromadd = waykey["tiger:lfromadd"]
             else:
@@ -269,17 +289,17 @@ def addressways(waylist, nodelist, first_id):
                 ltoadd = None
             if "tiger:rfromadd" in waykey:
                 rfromadd = waykey["tiger:rfromadd"]
-            else: 
+            else:
                 rfromadd = None
             if "tiger:rtoadd" in waykey:
                 rtoadd = waykey["tiger:rtoadd"]
             else:
                 rtoadd = None
-            if rfromadd != None and rtoadd != None:
+            if rfromadd is not None and rtoadd is not None:
                 right = True
             else:
                 right = False
-            if lfromadd != None and ltoadd != None:
+            if lfromadd is not None and ltoadd is not None:
                 left = True
             else:
                 left = False
@@ -296,7 +316,7 @@ def addressways(waylist, nodelist, first_id):
                     lon_feet = 365527.822 * math.cos(lrad) - 306.75853 * math.cos(3 * lrad) + 0.3937 * math.cos(5 * lrad)
 
 #Calculate the points of the offset ways
-                    if lastpoint != None:
+                    if lastpoint is not None:
                         #Skip points too close to start
                         if math.sqrt((lat * lat_feet - firstpoint[0] * lat_feet)**2 + (lon * lon_feet - firstpoint[1] * lon_feet)**2) < pullback:
                             #Preserve very short ways (but will be rendered backwards)
@@ -325,7 +345,7 @@ def addressways(waylist, nodelist, first_id):
                             Xp = -Xp
                         else:
                             Yp = -Yp
-                                
+
                         if first:
                             first = False
                             dX =  - (Yp * (pullback / distance)) / lon_feet #Pull back the first point
@@ -355,7 +375,7 @@ def addressways(waylist, nodelist, first_id):
                                 id += 1
                             if right:
                                 rpoint = (lastpoint[0] - (Yp + delta[0]) * r / (lat_feet * 2), lastpoint[1] - (Xp + delta[1]) * r / (lon_feet * 2))
-                                
+
                                 rsegment.append( (id, rpoint) )
                                 id += 1
 
@@ -395,12 +415,12 @@ def addressways(waylist, nodelist, first_id):
 
 #Write the nodes of the offset ways
                 if right:
-                    rlinestring = [];
-                    for i, point in rsegment:
+                    rlinestring = []
+                    for _i, point in rsegment:
                         rlinestring.append( "%f %f" % (point[1], point[0]) )
                 if left:
-                    llinestring = [];
-                    for i, point in lsegment:
+                    llinestring = []
+                    for _i, point in lsegment:
                         llinestring.append( "%f %f" % (point[1], point[0]) )
                 if right:
                     rsegments.append( rsegment )
@@ -429,14 +449,14 @@ def addressways(waylist, nodelist, first_id):
                 if right:
                     id += 1
 
-                    interpolationtype = "all";
+                    interpolationtype = "all"
                     if rtofromint:
                         if (rfromint % 2) == 0 and (rtoint % 2) == 0:
                             if ltofromint and (lfromint % 2) == 1 and (ltoint % 2) == 1:
-                                interpolationtype = "even";
+                                interpolationtype = "even"
                         elif (rfromint % 2) == 1 and (rtoint % 2) == 1:
                             if ltofromint and (lfromint % 2) == 0 and (ltoint % 2) == 0:
-                                interpolationtype = "odd";
+                                interpolationtype = "odd"
 
                         csv_lines.append({
                             'from': int(rfromadd),
@@ -447,18 +467,18 @@ def addressways(waylist, nodelist, first_id):
                             'state': state,
                             'postcode': zipr,
                             'geometry': 'LINESTRING(' + ','.join(rlinestring) + ')'
-                        });
+                        })
                 if left:
                     id += 1
 
-                    interpolationtype = "all";
+                    interpolationtype = "all"
                     if ltofromint:
                         if (lfromint % 2) == 0 and (ltoint % 2) == 0:
                             if rtofromint and (rfromint % 2) == 1 and (rtoint % 2) == 1:
-                                interpolationtype = "even";
+                                interpolationtype = "even"
                         elif (lfromint % 2) == 1 and (ltoint % 2) == 1:
                             if rtofromint and (rfromint %2 ) == 0 and (rtoint % 2) == 0:
-                                interpolationtype = "odd";
+                                interpolationtype = "odd"
 
                         csv_lines.append({
                             'from': int(lfromadd),
@@ -469,7 +489,7 @@ def addressways(waylist, nodelist, first_id):
                             'state': state,
                             'postcode': zipl,
                             'geometry': 'LINESTRING(' + ','.join(llinestring) + ')'
-                        });
+                        })
 
     return csv_lines
 
@@ -482,18 +502,18 @@ def round_point( point, accuracy=8 ):
 
 def compile_nodelist( parsed_gisdata, first_id=1 ):
     nodelist = {}
-    
+
     i = first_id
-    for geom, tags in parsed_gisdata:
+    for geom, _tags in parsed_gisdata:
         if len( geom )==0:
             continue
-        
+
         for point in geom:
             r_point = round_point( point )
             if r_point not in nodelist:
                 nodelist[ r_point ] = (i, unproject( point ))
                 i += 1
-            
+
     return (i, nodelist)
 
 def adjacent( left, right ):
@@ -501,99 +521,99 @@ def adjacent( left, right ):
     left_right = round_point(left[-1])
     right_left = round_point(right[0])
     right_right = round_point(right[-1])
-    
+
     return ( left_left == right_left or
              left_left == right_right or
              left_right == right_left or
              left_right == right_right )
-             
+
 def glom( left, right ):
     left = list( left )
     right = list( right )
-    
+
     left_left = round_point(left[0])
     left_right = round_point(left[-1])
     right_left = round_point(right[0])
     right_right = round_point(right[-1])
-    
+
     if left_left == right_left:
         left.reverse()
         return left[0:-1] + right
-        
+
     if left_left == right_right:
         return right[0:-1] + left
-        
+
     if left_right == right_left:
         return left[0:-1] + right
-        
+
     if left_right == right_right:
         right.reverse()
         return left[0:-1] + right
-        
+
     raise 'segments are not adjacent'
 
 def glom_once( segments ):
     if len(segments)==0:
         return segments
-    
+
     unsorted = list( segments )
     x = unsorted.pop(0)
-    
+
     while len( unsorted ) > 0:
         n = len( unsorted )
-        
+
         for i in range(0, n):
             y = unsorted[i]
             if adjacent( x, y ):
                 y = unsorted.pop(i)
                 x = glom( x, y )
                 break
-                
+
         # Sorted and unsorted lists have no adjacent segments
         if len( unsorted ) == n:
             break
-            
+
     return x, unsorted
-    
+
 def glom_all( segments ):
     unsorted = segments
     chunks = []
-    
+
     while unsorted != []:
         chunk, unsorted = glom_once( unsorted )
         chunks.append( chunk )
-        
+
     return chunks
-        
-                
+
+
 
 def compile_waylist( parsed_gisdata ):
     waylist = {}
-    
+
     #Group by tiger:way_id
     for geom, tags in parsed_gisdata:
         way_key = tags.copy()
         way_key = ( way_key['tiger:way_id'], tuple( [(k,v) for k,v in way_key.items()] ) )
-        
+
         if way_key not in waylist:
             waylist[way_key] = []
-            
+
         waylist[way_key].append( geom )
-    
+
     ret = {}
-    for (way_id, way_key), segments in waylist.items():
+    for (_way_id, way_key), segments in waylist.items():
         ret[way_key] = glom_all( segments )
     return ret
-            
+
 
 def shape_to_csv( shp_filename, csv_filename ):
-    
+
     print("parsing shpfile %s" % shp_filename)
     parsed_features = parse_shp_for_geom_and_tags( shp_filename )
-    
+
     print("compiling nodelist")
     i, nodelist = compile_nodelist( parsed_features )
-    
+
     print("compiling waylist")
     waylist = compile_waylist( parsed_features )
 
@@ -606,9 +626,8 @@ def shape_to_csv( shp_filename, csv_filename ):
         csv_writer = csv.DictWriter(f, delimiter=';', fieldnames=fieldnames)
         csv_writer.writeheader()
         csv_writer.writerows(csv_lines)
-    
+
 if __name__ == '__main__':
-    import sys, os.path
     if len(sys.argv) < 3:
         print("%s input.shp output.csv" % sys.argv[0])
         sys.exit()


### PR DESCRIPTION
Resolves 93 of 216 pylint warnings:

- trailing whitespace
- unnecessary semicolon
- missing module docstring
- import should be placed at the top of the module
- multiple imports on one line
- reimport 'sys'
- several long lines
- 'var != None' should be 'var is not None'
- uppercase constant names
- removed unused variables or prefixed with _
- converted some variables to snake_case naming style



