### PR TITLE
new script tiger_csv2sql.py, 2020->2021

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,10 +16,10 @@ Replace '2020' with the current year throughout.
         sudo apt-get install python3-gdal python3-pip unzip
         pip3 install -r requirements.txt
 
-  2. Get the TIGER 2020 data. You will need the EDGES files
+  2. Get the TIGER 2021 data. You will need the EDGES files
      (3,234 zip files, 11GB total).
 
-         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2020/EDGES/
+         wget -r ftp://ftp2.census.gov/geo/tiger/TIGER2021/EDGES/
 
   3. Convert the data into CSV files. Adjust the file paths in the scripts as needed
 
@@ -27,7 +27,7 @@ Replace '2020' with the current year throughout.
 
   4. Maybe: package the created files
   
-        tar -czf tiger2020-nominatim-preprocessed.tar.gz tiger
+        tar -czf tiger2021-nominatim-preprocessed.tar.gz tiger
 
 
 License

--- a/lib/csv2sql.py
+++ b/lib/csv2sql.py
@@ -1,0 +1,18 @@
+def sql_quote(string):
+    """
+    Ideally we'd use a standard library but this logic was used for
+    several years when creating the (now legacy) SQL
+    """
+    return "'" + string.replace("'", "''") + "'"
+
+def csv_row_to_sql(row):
+    sql = "SELECT tiger_line_import(ST_GeomFromText(%s,4326), %s, %s, %s, %s, %s, %s);" % (
+        sql_quote(row['geometry']),
+        sql_quote(row['from']),
+        sql_quote(row['to']),
+        sql_quote(row['interpolation']),
+        sql_quote(row['street']),
+        sql_quote(row['city'] + ', ' + row['state']),
+        sql_quote(row['postcode'])
+    )
+    return sql

--- a/tests/test_csv2sql.py
+++ b/tests/test_csv2sql.py
@@ -1,0 +1,23 @@
+import pytest
+
+from csv import DictReader
+from lib.csv2sql import csv_row_to_sql
+
+def test_csv_row_to_sql_insert_statement():
+    expected_sql = """\
+SELECT tiger_line_import(ST_GeomFromText('LINESTRING(-76.522044 36.329949,
+-76.521875 36.330054,-76.521658 36.330172,-76.521413 36.330273,-76.517666 36.331101,
+-76.516307 36.331427,-76.515502 36.331724,-76.514664 36.332228,-76.514336 36.332422,
+-76.514075 36.332541,-76.512989 36.332949,-76.509631 36.334319,-76.508420 36.334731,
+-76.506860 36.335057,-76.506263 36.335119,-76.505727 36.335112,-76.505198 36.335046,
+-76.504733 36.334942,-76.503785 36.334640,-76.503451 36.334492,-76.502998 36.334240,
+-76.502578 36.333963,-76.502129 36.333622,-76.501708 36.333245,-76.501068 36.332746,
+-76.500606 36.332353)',4326), '389', '101', 'odd', 'Hickory Cross Rd', 'Perquimans, NC', '27919');
+""".replace("\n", "")
+
+    with open('tests/fixtures/expected_37143.csv') as file:
+        csv_reader = DictReader(file, delimiter=';')
+        for row in csv_reader:
+            sql = csv_row_to_sql(row)
+            assert sql == expected_sql
+            break

--- a/tiger_csv2sql.py
+++ b/tiger_csv2sql.py
@@ -1,0 +1,13 @@
+#!/usr/bin/env python3
+
+"""
+Reads CSV with header from STDIN, print SQL to STDOUT
+"""
+
+import sys
+from csv import DictReader
+from lib.csv2sql import csv_row_to_sql
+
+csv_reader = DictReader(sys.stdin, delimiter=';')
+for row in csv_reader:
+    print(csv_row_to_sql(row))


### PR DESCRIPTION
We create CSV files, but Nominatim cannot read those yet. So adding a converting script which outputs the (legacy) SQL files.

We used to create SQL file as `"\n".join(rows)` so they didn't have a newline in the last line of the file. The converting script adds a newline. Otherwise the output is the same.