### PR TITLE
docs: fix code block formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,25 +26,25 @@ Replace '2025' with the current year throughout.
 
      Alternatively
 
-         ```bash
-         curl 'https://www2.census.gov/geo/tiger/TIGER2025/EDGES/' | grep -o 'tl_[^"]*.zip' | sort -u > filelist.txt
-         # 3235 filelist.txt
-         cat filelist.txt | sed -e 's!^!https://www2.census.gov/geo/tiger/TIGER2025/EDGES/!' | xargs -n 1 wget
-         ```
+        ```bash
+        curl 'https://www2.census.gov/geo/tiger/TIGER2025/EDGES/' | grep -o 'tl_[^"]*.zip' | sort -u > filelist.txt
+        # 3235 filelist.txt
+        cat filelist.txt | sed -e 's!^!https://www2.census.gov/geo/tiger/TIGER2025/EDGES/!' | xargs -n 1 wget
+        ```
 
   3. Convert the data into CSV files. Adjust the file paths in the scripts as needed
 
-         ```bash
-         ./convert.sh <input-path> <output-path> 2>&1 | tee convert.$$.log
-         cd output-path
-         ./patch.sh
-         ```
+        ```bash
+        ./convert.sh <input-path> <output-path> 2>&1 | tee convert.$$.log
+        cd output-path
+        ./patch.sh
+        ```
 
   4. Maybe: package the created files
   
         ```bash
         tar -czf tiger2025-nominatim-preprocessed.csv.tar.gz *.csv
-         ```
+        ```
 
 
 US Postcodes


### PR DESCRIPTION
Noticed that the code blocks were improperly formatted.

<details>

<summary>They're currently rendering like this on GitHub:</summary>

<img width="1702" height="994" alt="CleanShot 2026-02-23 at 12 37 08@2x" src="https://github.com/user-attachments/assets/2bc7da04-5a83-47f1-8c22-25fb293b924e" />

</details>


<details>

<summary>This PR fixes them up so they look like this:</summary>

<img width="1702" height="768" alt="CleanShot 2026-02-23 at 12 37 16@2x" src="https://github.com/user-attachments/assets/0e30fe91-10e3-4720-96f0-8b50cf01e97b" />

</details>